### PR TITLE
Fix Fixnum warning on Ruby 2.4+

### DIFF
--- a/lib/event_emitter/emitter.rb
+++ b/lib/event_emitter/emitter.rb
@@ -32,7 +32,7 @@ module EventEmitter
     alias :on :add_listener
 
     def remove_listener(id_or_type)
-      if id_or_type.class == Fixnum
+      if id_or_type.is_a? Integer
         __events.delete_if do |e|
           e[:id] == id_or_type
         end


### PR DESCRIPTION
Fixnum and Bignum were deprecated in Ruby 2.4+, replaced by Integer.