### PR TITLE
Preserve the lexical scope of the listener

### DIFF
--- a/lib/event_emitter/emitter.rb
+++ b/lib/event_emitter/emitter.rb
@@ -50,11 +50,11 @@ module EventEmitter
         when type
           listener = e[:listener]
           e[:type] = nil if e[:params][:once]
-          instance_exec(*data, &listener)
+          listener.call(*data)
         when :*
           listener = e[:listener]
           e[:type] = nil if e[:params][:once]
-          instance_exec(type, *data, &listener)
+          listener.call(type, *data)
         end
       end
       __events.each do |e|

--- a/test/test_catch_all_events.rb
+++ b/test/test_catch_all_events.rb
@@ -18,10 +18,10 @@ class TestCatchAllEvents < MiniTest::Test
     called_event = nil
     @foo.on :* do |event|
       called_event = event
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
     @foo.on :bar do
-      created_at_ = self.created_at
+      created_at_ = @foo.created_at
     end
     @foo.emit :bar
 

--- a/test/test_class_method.rb
+++ b/test/test_class_method.rb
@@ -19,7 +19,7 @@ class TestClassMethod < MiniTest::Test
   def test_simple
     created_at = nil
     Foo.on :bar do
-      created_at = self.created_at
+      created_at = Foo.created_at
     end
     Foo.emit :bar
 
@@ -31,7 +31,7 @@ class TestClassMethod < MiniTest::Test
     created_at = nil
     Foo.on :chat do |data|
       result = data
-      created_at = self.created_at
+      created_at = Foo.created_at
     end
 
     Foo.emit :chat, :user => 'shokai', :message => 'hello world'
@@ -50,7 +50,7 @@ class TestClassMethod < MiniTest::Test
       _user = user
       _message = message
       _session = session
-      created_at = self.created_at
+      created_at = Foo.created_at
     end
 
     sid = Time.now.to_i
@@ -67,7 +67,7 @@ class TestClassMethod < MiniTest::Test
     created_at = nil
     Foo.add_listener :chat do |data|
       result = data
-      created_at = self.created_at
+      created_at = Foo.created_at
     end
 
     Foo.emit :chat, :user => 'shokai', :message => 'hello world'

--- a/test/test_event_emitter.rb
+++ b/test/test_event_emitter.rb
@@ -15,7 +15,7 @@ class TestEventEmitter < MiniTest::Test
   def test_simple
     created_at = nil
     @foo.on :bar do
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
     @foo.emit :bar
 
@@ -25,7 +25,7 @@ class TestEventEmitter < MiniTest::Test
   def test_string_event_name
     created_at = nil
     @foo.on "bar" do
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
     @foo.emit :bar
   end
@@ -35,7 +35,7 @@ class TestEventEmitter < MiniTest::Test
     created_at = nil
     @foo.on :chat do |data|
       result = data
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
 
     @foo.emit :chat, :user => 'shokai', :message => 'hello world'
@@ -54,7 +54,7 @@ class TestEventEmitter < MiniTest::Test
       _user = user
       _message = message
       _session = session
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
 
     sid = Time.now.to_i
@@ -71,7 +71,7 @@ class TestEventEmitter < MiniTest::Test
     created_at = nil
     @foo.add_listener :chat do |data|
       result = data
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
 
     @foo.emit :chat, :user => 'shokai', :message => 'hello world'

--- a/test/test_lexical_scope.rb
+++ b/test/test_lexical_scope.rb
@@ -1,0 +1,38 @@
+require File.expand_path 'test_helper', File.dirname(__FILE__)
+
+class TestLexicalScope < MiniTest::Test
+
+  class Foo
+    include EventEmitter
+  end
+
+  class Bar
+    def initialize(foo)
+      @foo = foo
+    end
+
+    def reply
+      'hi'
+    end
+
+    attr_accessor :response
+
+    def setup
+      @foo.on :hello do
+        @response = reply
+      end
+    end
+  end
+
+  def setup
+    @foo = Foo.new
+    @bar = Bar.new(@foo)
+    @bar.setup
+  end
+
+  def test_simple
+    assert @bar.response == nil
+    @foo.emit :hello
+    assert @bar.response == @bar.reply
+  end
+end

--- a/test/test_singular_method.rb
+++ b/test/test_singular_method.rb
@@ -15,7 +15,7 @@ class TestSingularMethod < MiniTest::Test
   def test_simple
     created_at = nil
     @foo.on :bar do
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
     @foo.emit :bar
 
@@ -27,7 +27,7 @@ class TestSingularMethod < MiniTest::Test
     created_at = nil
     @foo.on :chat do |data|
       result = data
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
 
     @foo.emit :chat, :user => 'shokai', :message => 'hello world'
@@ -46,7 +46,7 @@ class TestSingularMethod < MiniTest::Test
       _user = user
       _message = message
       _session = session
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
 
     sid = Time.now.to_i
@@ -63,7 +63,7 @@ class TestSingularMethod < MiniTest::Test
     created_at = nil
     @foo.add_listener :chat do |data|
       result = data
-      created_at = self.created_at
+      created_at = @foo.created_at
     end
 
     @foo.emit :chat, :user => 'shokai', :message => 'hello world'


### PR DESCRIPTION
Hello @shokai, I like how your event emitter library is so clean, concise, and easy to read!

I was surprised that it doesn't preserve the lexical scope of the listener.

Given the following event emitter code:
```rb
class Foo
  include EventEmitter
end

class Bar
  def initialize(foo)
    @foo = foo
  end

  def reply
    'hi'
  end

  attr_accessor :response

  def setup
    @foo.on :hello do
      @response = reply
    end
  end
end

@foo = Foo.new
@bar = Bar.new(@foo)
@bar.setup
```
When I emit the `:hello` event:
```rb
@foo.emit :hello
```
Then the `:hello` listener from `@bar` throws the following exception:
```
NameError: undefined local variable or method `reply' for #<Foo:0x00005564cad602c0>
```

I would like it if the `:hello` listener from `@bar` had access to the scope of `@bar` instead of the scope of `@foo`.

What do you think? This would be a breaking change, so we would probably have to release this as version `1.0.0` rather than `0.2.7`.